### PR TITLE
fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ List of awesome things and resources about GNU Guix (https://guix.gnu.org). Pull
 
   _Reference card_
 
-- <https://www.gnu.org/software/guile/manual/>
+- <https://guix.gnu.org/manual/>
 
   _GNU Guix Manual_
 
@@ -19,7 +19,7 @@ List of awesome things and resources about GNU Guix (https://guix.gnu.org). Pull
 
 - Solving the deployment crisis with GNU Guix - Dave Thompson, Christopher Webber - LibrePlanet 2016 ([video](https://www.youtube.com/watch?v=iM3y9CSjMtI), [pdf](https://media.libreplanet.org/mgoblin_media/media_entries/1420/libreplanet_guix.pdf))
 
-- <https://ambrevar.xyz/guix-advance/>
+- <https://web.archive.org/web/20211120165407/https://ambrevar.xyz/guix-advance/>
 
   _Guix: A most advanced operating system (and: A quick look at the history of operating systems)_
 


### PR DESCRIPTION
Guix Manual link was guile manual link.
Also, a link was dead, so I replaced it with its archive.